### PR TITLE
fix exception caused by solr plugin classloader

### DIFF
--- a/morphology/src/main/java/zemberek/morphology/lexicon/tr/TurkishDictionaryLoader.java
+++ b/morphology/src/main/java/zemberek/morphology/lexicon/tr/TurkishDictionaryLoader.java
@@ -32,15 +32,6 @@ import static zemberek.core.turkish.TurkishAlphabet.L_r;
 
 public class TurkishDictionaryLoader {
 
-    public static final List<File> DEFAULT_DICTIONARY_FILES = ImmutableList.of(
-            new File(Resources.getResource("tr/master-dictionary.dict").getFile()),
-            new File(Resources.getResource("tr/secondary-dictionary.dict").getFile()),
-            new File(Resources.getResource("tr/non-tdk.dict").getFile()),
-            new File(Resources.getResource("tr/proper.dict").getFile()),
-            new File(Resources.getResource("tr/proper-from-corpus.dict").getFile()),
-            new File(Resources.getResource("tr/abbreviations.dict").getFile())
-    );
-
     public static final List<String> DEFAULT_DICTIONARY_RESOURCES = ImmutableList.of(
             "tr/master-dictionary.dict",
             "tr/secondary-dictionary.dict",
@@ -101,6 +92,14 @@ public class TurkishDictionaryLoader {
     }
 
     public static RootLexicon loadDefaultDictionaries(final SuffixProvider suffixProvider) throws IOException {
+        final List<File> DEFAULT_DICTIONARY_FILES = ImmutableList.of(
+                new File(Resources.getResource("tr/master-dictionary.dict").getFile()),
+                new File(Resources.getResource("tr/secondary-dictionary.dict").getFile()),
+                new File(Resources.getResource("tr/non-tdk.dict").getFile()),
+                new File(Resources.getResource("tr/proper.dict").getFile()),
+                new File(Resources.getResource("tr/proper-from-corpus.dict").getFile()),
+                new File(Resources.getResource("tr/abbreviations.dict").getFile())
+        );
         List<String> lines = Lists.newArrayList();
         for (File file : DEFAULT_DICTIONARY_FILES) {
             lines.addAll(SimpleTextReader.trimmingUTF8Reader(file).asStringList());


### PR DESCRIPTION
Today, zemberek-morphology-0.9.2.jar cannot be loaded as a [SolrPlugin] (http://wiki.apache.org/solr/SolrPlugins). I know it works OK as a standalone app, when it is loaded by Solr plugin class-loader an exception occurs. Please fix this one. Then https://github.com/iorixxx/lucene-solr-analysis-turkish can consume it without modification. Thanks.