### PR TITLE
Replace addDictionaryLines() with getLexicon()

### DIFF
--- a/morphology/README.md
+++ b/morphology/README.md
@@ -315,7 +315,7 @@ You can run this example from `zemberek.examples.morphology.GenerateWords` in ex
     String[] cases = {"Dat", "Loc", "Abl"};
 
     TurkishMorphology morphology =
-        TurkishMorphology.builder().addDictionaryLines("armut").disableCache().build();
+        TurkishMorphology.builder().setLexicon("armut").disableCache().build();
 
     DictionaryItem item = morphology.getLexicon().getMatchingItems("armut").get(0);
     for (String numberM : number) {


### PR DESCRIPTION
The word generation example inside the `README.md` was using `addDictionaryLines()` instead of `getLexicon()`.