### PR TITLE
Implementing IndexedString to keep track of changes to a string during normalization

### DIFF
--- a/examples/src/main/java/zemberek/examples/normalization/NormalizeNoisyText.java
+++ b/examples/src/main/java/zemberek/examples/normalization/NormalizeNoisyText.java
@@ -34,7 +34,7 @@ public class NormalizeNoisyText {
 
     for (String example : examples) {
       System.out.println(example);
-      System.out.println(normalizer.normalize(example));
+      System.out.println(normalizer.normalize(example).toString());
       System.out.println();
     }
 

--- a/experiment/src/main/java/zemberek/classification/ClassificationExperiment.java
+++ b/experiment/src/main/java/zemberek/classification/ClassificationExperiment.java
@@ -132,12 +132,12 @@ public class ClassificationExperiment extends ClassificationExampleBase {
     train = train.stream()
         .filter(s -> s.contains("__label__"))
         .map(s -> s.replaceAll("^\"", ""))
-        .map(s -> normalizer.normalize(s))
+        .map(s -> normalizer.normalize(s).toString())
         .collect(Collectors.toList());
     test = test.stream()
         .filter(s -> s.contains("__label__"))
         .map(s -> s.replaceAll("^\"", ""))
-        .map(s -> normalizer.normalize(s))
+        .map(s -> normalizer.normalize(s).toString())
         .collect(Collectors.toList());
 
     Log.info("After pre-process, Train = %d, Test = %d lines.", train.size(), test.size());

--- a/experiment/src/main/java/zemberek/classification/SentimentClassifier.java
+++ b/experiment/src/main/java/zemberek/classification/SentimentClassifier.java
@@ -91,7 +91,7 @@ public class SentimentClassifier extends ClassificationExampleBase {
       }
       String content = line.substring(0, i).trim();
       normalizer.setAlwaysApplyDeasciifier(true);
-      content = normalizer.normalize(content);
+      content = normalizer.normalize(content).toString();
       String label = "__label__" + line.substring(i).trim();
       result.add(label + " " + content);
     }

--- a/grpc/src/main/java/zemberek/grpc/server/NormalizationServiceImpl.java
+++ b/grpc/src/main/java/zemberek/grpc/server/NormalizationServiceImpl.java
@@ -33,7 +33,7 @@ public class NormalizationServiceImpl extends NormalizationServiceImplBase {
     String normalized;
     if (sentenceNormalizer != null) {
       String s = request.getInput();
-      normalized = sentenceNormalizer.normalize(s);
+      normalized = sentenceNormalizer.normalize(s).toString();
       responseObserver.onNext(NormalizationResponse.newBuilder()
           .setNormalizedInput(normalized)
           .build());

--- a/normalization/src/main/java/zemberek/normalization/IndexedString.java
+++ b/normalization/src/main/java/zemberek/normalization/IndexedString.java
@@ -1,0 +1,78 @@
+package zemberek.normalization;
+
+import javafx.util.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Class that keeps track of changes made to a string such that each character in the new string can be mapped
+ * to a substring in the original string.
+ */
+public class IndexedString {
+
+    private List<Pair<Integer, Integer>> indices;
+    private StringBuilder stringBuilder;
+
+    IndexedString() {
+        stringBuilder = new StringBuilder();
+        indices = new ArrayList<>();
+    }
+
+
+    IndexedString(String string, List<Pair<Integer, Integer>> indices) {
+        assert(string.length() == indices.size());
+        stringBuilder = new StringBuilder(string);
+        this.indices = indices;
+    }
+
+    IndexedString(String string) {
+        stringBuilder = new StringBuilder(string);
+        this.indices = new ArrayList<>();
+        for(int i=0; i < string.length(); i++) {
+            this.indices.add(new Pair<>(i, i));
+        }
+    }
+
+    public Integer getStartIndex(int i) {
+        return indices.get(i).getKey();
+    }
+
+    public Integer getEndIndex(int i) {
+        return indices.get(i).getValue();
+    }
+
+    public String toString() {
+        return stringBuilder.toString();
+    }
+
+    public List<Pair<Integer, Integer>> getIndices() {
+        return indices;
+    }
+
+    public void add(String string, int startIndex, int endIndex, IndexedString ns) {
+        if (stringBuilder.length() > 0) {
+            stringBuilder.append(" ");
+            indices.add(new Pair<>(-1, -1));
+        }
+        stringBuilder.append(string);
+        for(int i = 0; i<string.length(); i++) {
+            indices.add(new Pair<>(ns.getStartIndex(startIndex), ns.getEndIndex(endIndex)));
+        }
+    }
+
+    void reverse() {
+        stringBuilder.reverse();
+        Collections.reverse(indices);
+    }
+
+    /**
+     * Returns the substring of a string according to the indices in the normalized string.
+     */
+
+    public String getSubstring(String original, int normalizedStartIndex, int normalizedEndIndex) {
+        return original.substring(getStartIndex(normalizedStartIndex), getEndIndex(normalizedEndIndex)+1);
+    }
+
+}

--- a/normalization/src/main/java/zemberek/normalization/ProcessNormalizationCorpus.java
+++ b/normalization/src/main/java/zemberek/normalization/ProcessNormalizationCorpus.java
@@ -71,7 +71,7 @@ public class ProcessNormalizationCorpus {
       service.submit(() -> {
         List<String> sentences = TextCleaner.cleanAndExtractSentences(chunk.getData());
         sentences = sentences.stream()
-            .map(s -> normalizer.preProcess(s))
+            .map(s -> normalizer.preProcess(s).toString())
             .collect(Collectors.toList());
         Path p = outRoot.resolve(String.valueOf(c.getAndIncrement()));
         try {

--- a/normalization/src/test/java/zemberek/normalization/BotExperiment.java
+++ b/normalization/src/test/java/zemberek/normalization/BotExperiment.java
@@ -42,7 +42,7 @@ public class BotExperiment {
 
     String input = "tmm bu akşm dönücem sana";
     Log.info(input);
-    Log.info(String.join(" ", normalizer.normalize(input)));
+    Log.info(String.join(" ", normalizer.normalize(input).toString()));
 
     Log.info("Done.");
 
@@ -91,7 +91,7 @@ public class BotExperiment {
       for (String line : lines) {
         tokenCount += TurkishTokenizer.DEFAULT.tokenize(line).size();
         lineCount++;
-        String n = normalizer.normalize(line);
+        String n = normalizer.normalize(line).toString();
         if (!n.equals(line)) {
           pw.println(line);
           pw.println(n);


### PR DESCRIPTION
In some cases it is useful to know what the original word form of a word or substring was after a string is normalized. This means that the changes that are made during normalization need to be tracked.
This PR does exactly that and allows users of the API to extract the original substring for indices in the normalized string.