### PR TITLE
check token type for EOF before converting

### DIFF
--- a/tokenization/src/main/java/zemberek/tokenization/TurkishTokenizer.java
+++ b/tokenization/src/main/java/zemberek/tokenization/TurkishTokenizer.java
@@ -213,10 +213,10 @@ public class TurkishTokenizer {
       type = convertType(token);
       while (tokenizer.typeIgnored(type)) {
         token = lexer.nextToken();
-        type = convertType(token);
         if (token.getType() == org.antlr.v4.runtime.Token.EOF) {
           return false;
         }
+        type = convertType(token);
       }
       this.token = token;
       return true;


### PR DESCRIPTION
hasNext() throws if the EOF token comes after an ignored token. 

`
Caused by: java.lang.IllegalStateException: Unidentified token type =EOF
        at zemberek.tokenization.TurkishTokenizer.convertType(TurkishTokenizer.java:161) ~[?:?]
        at zemberek.tokenization.TurkishTokenizer$TokenIterator.hasNext(TurkishTokenizer.java:219) ~[?:?]
`