### PR TITLE
Fix locale dependent float formatting

### DIFF
--- a/core/src/main/java/zemberek/core/math/FloatArrays.java
+++ b/core/src/main/java/zemberek/core/math/FloatArrays.java
@@ -334,7 +334,7 @@ public class FloatArrays {
     String formatStr = "%." + fractionDigits + "f";
     int i = 0;
     for (float v : input) {
-      String num = String.format(formatStr, v);
+      String num = String.format(Locale.ENGLISH, formatStr, v);
       sb.append(String.format(Locale.ENGLISH, "%-" + rightPad + "s", num));
       if (i++ < input.length - 1) {
         sb.append(delimiter);


### PR DESCRIPTION
This test case fails:
https://github.com/ahmetaa/zemberek-nlp/blob/e6e292ffc4aab59e4c26ed40129d3ef1e356b903/core/src/test/java/zemberek/core/math/FloatArraysTest.java#L328

```
Stack trace:
org.junit.ComparisonFailure: expected:<0[.2   -0.4  0.]6> but was:<0[,2   -0,4  0,]6>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at zemberek.core.math.FloatArraysTest.testFormat(FloatArraysTest.java:328)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:542)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:770)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:464)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:210)
```